### PR TITLE
add group support to list command

### DIFF
--- a/lib/smith/commands/agency/list.rb
+++ b/lib/smith/commands/agency/list.rb
@@ -1,12 +1,23 @@
 # -*- encoding: utf-8 -*-
+
+require_relative '../common'
+
 module Smith
   module Commands
     class List < CommandBase
+
+      include Common
+
       def execute
         if target.size > 0
           selected_agents = agents.find_by_name(target)
         else
           selected_agents = (options[:all]) ? agents.to_a : agents.state(:running)
+        end
+
+        if options[:group]
+          group_names = agent_group(options[:group])
+          selected_agents = selected_agents.select { |a| group_names.include?(a.name) }
         end
 
         responder.succeed((selected_agents.empty?) ? '' : format(selected_agents, options[:long]))
@@ -51,6 +62,7 @@ module Smith
         banner "List the running agents."
 
         opt         :long,       "the number of times to send the message", :short => :l
+        opt         :group,      "list only agents in this group", :type => :string, :short => :g
         opt         :one_column, "the number of times to send the message", :short => :s
         opt         :all,        "show all agents in all states", :short => :a
 


### PR DESCRIPTION
After I though about it I realised that the `all` option didn't conflict with `group`, so we would still need to consider that. I tried to do it the way you suggested and not load agents then filter afterward, but couldn't think of an easy way to do that which didn't involve duplicating the filter for `state` after. 

The main issue was that both `#find_by_name` and `#state` returned arrays (and not the fancy agents enumerable), thus they could not be chained in any obvious way, so the filtering using a `#select` seemed inevitable. Though it may, I suppose, have been possible to get the array and construct another fancy enumerable from that.

I have tested this locally to much delicious success:
```ruby
$ bin/smithctl list -la
total 3
stopping  753ebf3b-fd1a-49c1-8418-1e1c34da860e  95204  2014/10/16 17:12:35  (agent dead)  InstagramPostPersistAgent
running   39acbcbd-3d21-448b-bd0b-0e5723aa6ad3  14315  2014/11/12 16:31:56                InstagramPostgresPostPersistAgent
running   0713076a-6c66-4fad-a392-8be79e2fc5ca  81593  2014/11/13 08:20:03                InstagramPostsUserReportAgent

$ bin/smithctl list -l
total 2
running  39acbcbd-3d21-448b-bd0b-0e5723aa6ad3  14315  2014/11/12 16:31:56    InstagramPostgresPostPersistAgent 
running  0713076a-6c66-4fad-a392-8be79e2fc5ca  81593  2014/11/13 08:20:03    InstagramPostsUserReportAgent

$ bin/smithctl list -lg satin
total 1
running  39acbcbd-3d21-448b-bd0b-0e5723aa6ad3  14315  2014/11/12 16:31:56    InstagramPostgresPostPersistAgent 

$ bin/smithctl list -lag satin
total 2
stopping  753ebf3b-fd1a-49c1-8418-1e1c34da860e  95204  2014/10/16 17:12:35  (agent dead)  InstagramPostPersistAgent
running   39acbcbd-3d21-448b-bd0b-0e5723aa6ad3  14315  2014/11/12 16:31:56                InstagramPostgresPostPersistAgent
```