### PR TITLE
hacky fanout implementation

### DIFF
--- a/lib/smith/messaging/receiver.rb
+++ b/lib/smith/messaging/receiver.rb
@@ -38,7 +38,7 @@ module Smith
         @reply_queues = {}
 
         @fanout = opts[:fanout]
-        @fanout_persist = opts.key?(:fanout_persist) ? true : opts[:fanout_persist]
+        @fanout_persist = opts.fetch(:fanout_persist, true)
         @fanout_queue_suffix = opts[:fanout_queue_suffix]
 
         open_channel(:prefetch => prefetch) do |channel|


### PR DESCRIPTION
Just looking for feedback on how best to implement this. This changes the `sender` and `receiver` methods.

The change to `sender` method is that it now has a `:fanout` option. This has 2 effects when set to true:
 1. The exchange is declared as fanout
 2. no queue is bound to the exchange

The change to `receiver` is that it supports 2 new options. `:fanout` and `:queue_append`. When:

- `:fanout` is `true` but no `queue_append` is set: This is basically pubsub as the queue name is random and not durable and is auto_delete
- `:fanout` is `true` and `queue_append` is set: This means that once the queue is is bound to the exchange it is forever bound and thus will be kept even when agents are restarted. This leaves the responsibility of using a consistent name up to the receiving agent. Thus if you want to run 2 of the same agent that are round robining the messages then that agent just needs to consistently name the `queue_append`.

