### PR TITLE
Use the Logging gem’s public API to check if the logger is already initialised

### DIFF
--- a/lib/smith/logger.rb
+++ b/lib/smith/logger.rb
@@ -4,7 +4,7 @@ module Smith
 
     def self.included(base)
 
-      if !Logging.const_defined?(:MAX_LEVEL_LENGTH)
+      if !Logging.initialized?
         Logging.init([:verbose, :debug, :info, :warn, :error, :fatal])
       end
 


### PR DESCRIPTION
Replace access to the internal constant with `Logging.initialized?` which basically does the same thing, but doesn’t require access to the internal const directly.