### PR TITLE
Support multiple directories added to the $LOAD_PATH

### DIFF
--- a/config/smithrc.toml
+++ b/config/smithrc.toml
@@ -21,6 +21,13 @@ kqueue = true
 pid_directory = "~/.smith/run"
 cache_directory = "~/.smith/cache"
 
+# These directories get added to the Ruby $LOAD_PATH for agents to require code.
+lib_directories = ["lib"]
+# Shared codebase with a basic web app:
+#   lib_directories = ["lib", "app"]
+# Shared codebase with a Rails app:
+#   lib_directories = ["lib", "app/models", "vendor"]
+
 # This is the directory that will contain the agent groups
 group_directory = "groups"
 

--- a/lib/smith.rb
+++ b/lib/smith.rb
@@ -45,6 +45,10 @@ module Smith
       Pathname.new(__FILE__).dirname.parent.expand_path
     end
 
+    def lib_directories
+      config.agency.lib_directories
+    end
+
     def agent_directories
       config.agency.agent_directories
     end

--- a/lib/smith/bootstrap.rb
+++ b/lib/smith/bootstrap.rb
@@ -132,24 +132,26 @@ module Smith
       logger.error { "Terminating: #{@agent_name}, UUID: #{@agent_uuid}, PID: #{@pid.pid}." }
     end
 
-    # Add the ../lib to the load path. This assumes the directory
-    # structure is:
+    # Add directories with library code to the load path. This assumes that
+    # the required files reside at the same level as the agent directory.
+    #
+    # Always defaults to `lib` if a `lib_directories` list is not provided
+    # by the configuration.
     #
     # $ROOT_PATH/agents
     #        .../lib
     #
-    # where $ROOT_PATH can be anywhere.
-    #
-    # This needs to be better thought out.
-    # TODO think this through some more.
+    # Where $ROOT_PATH is dependent on the agent directory.
     def add_agent_load_path(path)
       Smith.agent_directories.each do |path|
-        lib_path = path.parent.join('lib')
-        if lib_path.exist?
-          logger.info { "Adding #{lib_path} to load path" }
-          $LOAD_PATH << lib_path
-        else
-          logger.info { "No lib directory for: #{path.parent}." }
+        Smith.lib_directories.each do |lib_dir|
+          lib_path = path.parent.join(lib_dir)
+          if lib_path.exist?
+            logger.info { "Adding #{lib_path} to load path." }
+            $LOAD_PATH << lib_path
+          else
+            logger.info { "#{lib_dir} directory not found in: #{path.parent}." }
+          end
         end
       end
     end


### PR DESCRIPTION
Adds a new configuration property to support configurable directory paths for loading shared code. This might be useful for agents which are deployed as part of a larger codebase with reusable modules and classes in an `app` directory.

Usage:

```toml
[agency]
lib_directories = ["lib", "app"]
```

Defaults to `["lib"]` so that the existing behaviour is preserved by default without needing to be explicitly configured.